### PR TITLE
Fix build on macOS by finding libssh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # See https://github.com/spook/sshping
 project(sshping)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(libssh REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 project(sshping)
 cmake_minimum_required(VERSION 2.8)
 
-#find_package(libssh)
+find_package(libssh REQUIRED)
 
 # Build the sshping binary
 include_directories(ext)


### PR DESCRIPTION
Thanks for this neat little tool! 

Was there a reason the `find_package(libssh)` line was commented out? If not, could we please add it back in and make it required?

With this it builds and runs on macOS and Linux for me.

The CMake version requirements were to remove a depreciation warning that I got. There is no particular reason I chose 3.10. 