### PR TITLE
Respect FHS for manpages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (UNIX)
 endif (UNIX)
 
 add_custom_target(man ALL DEPENDS ${MAN_TGT})
-install(FILES ${MAN_TGT} DESTINATION ${CMAKE_INSTALL_PREFIX}/man/man8)
+install(FILES ${MAN_TGT} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man8)
 
 # Packaging for RPM or DEB
 find_program(rpmbuild_path "rpmbuild" FALSE)


### PR DESCRIPTION
According the the FHS, manpages go in /usr/share/man:
https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html#usrsharemanManualPages

But sshping currently installs its manpage to
${CMAKE_INSTALL_PREFIX}/man. One could Set CMAKE_INSTALL_PREFIX to
/usr/share, but then one would get the sshping binary in /usr/share,
which isn't really desirable. The AUR package, for example, does
indeed install to /usr/share:

https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=sshping#n28

And I already have this patch for the ebuild in my overlay:

https://gitlab.com/ajak/ajak/-/blob/master/net-analyzer/sshping/files/sshping-0.1.4-fix-man-dir.patch

Signed-off-by: John Helmert III <ajak@gentoo.org>