### PR TITLE
Fix to support special character '@' in username

### DIFF
--- a/src/sshping.cxx
+++ b/src/sshping.cxx
@@ -205,7 +205,7 @@ const option::Descriptor usage[] = {
   char* strsep(char** stringp, const char* delim) {
       char* start = *stringp;
       char* p;
-      p = (start != NULL) ? strpbrk(start, delim) : NULL;
+      p = (start != NULL) ? strrchr(start, delim) : NULL;
       if (p == NULL) {
           *stringp = NULL;
       }
@@ -962,12 +962,12 @@ int main(int   argc,
 
     // Parse values
     port = (char*)parse.nonOption(0);
-    user = strsep(&port, "@");
+    user = strndup(port, strrchr(port, '@') - port);
     if (!port || !port[0]) {
         port = user;
         user = NULL;
     }
-    std::string ip = port;
+    std::string ip = strrchr(port, '@') + 1;
     std::string temp_port = parse_ip_address(ip);
     port = (char*)temp_port.c_str();
     addr = (char*)ip.c_str();


### PR DESCRIPTION
Hi, we are using this utility in [ShellHub](https://github.com/shellhub-io/shellhub/) to measure SSH latency in our SSH Cloud SaaS servers.

In ShellHub there is a concept called SSHID which in addition to the username, host and port, also contains the hostname of the target server (we called it SSHID).

SSHID address example:
```
user@target-server@ssh-bastion-host
```

This address is valid for the standard SSH Client (openSSH) where the username is parsed as `user@target-server` and host as `ssh-bastion-host` but sshping doesn't deal with it.

This PR fix it supporting '@' char in username.
