### PR TITLE
fixed segmentation fault during ending the process

### DIFF
--- a/src/sshping.cxx
+++ b/src/sshping.cxx
@@ -1074,7 +1074,7 @@ int main(int   argc,
     }
 
     // Cleanup
-    if (port) free(port);
+    if (!clpos && port) free(port);
     logout_channel(chn);
     end_session(ses);
 }


### PR DESCRIPTION
There is a cleaning up at the end of the program, including a 'free(port)'. However, only if the `strdup` is executed (src/sshping.cxx:983), the variable `port` needs to be freed. `strdup` is executed when there is no valid port provided in command line arguments, so I add `!clpos` in the condition of freeing which indicates no port was found from arguments.

It is the root cause of Issue Bug #37.

I tested the code and the program ends normally as
![image](https://github.com/spook/sshping/assets/23454622/8e27109d-3c06-4a09-bf74-ff2c76223706)
 from
![image](https://github.com/spook/sshping/assets/23454622/41d94605-de0c-4a29-8cf4-a64f02362970)
