### PR TITLE
fix missing brackets during IPv6 address parsing

### DIFF
--- a/src/sshping.cxx
+++ b/src/sshping.cxx
@@ -973,8 +973,6 @@ int main(int   argc,
         if (*addr != '[') {
           die("Unbalanced IPv6 address brackets\n", 255);
         }
-        *bkpos = '\0';
-        addr++;
     }
     if (!strlen(addr)) {
         die("Missing target address\n", 255);


### PR DESCRIPTION
It seems if the `host` argument in `ssh_options_set(session, SSH_OPTIONS_HOST, host)` is an IPv6 address,
this address should be enclosed with the brackets.

I only tested this PR with an IPv6 address. I have NOT verified the assumption above in the libssh documentation.