### PR TITLE
Don't error on `SSH_AGAIN` in `discard_output`

### DIFF
--- a/src/sshping.cxx
+++ b/src/sshping.cxx
@@ -362,11 +362,13 @@ int discard_output(ssh_channel & chn,
                                               sizeof(buffer),
                                               /*is-stderr*/ 0,
                                               max_wait);
+
+        if (nbytes == 0 || nbytes == SSH_AGAIN) {
+            return SSH_OK; // timeout, we're done
+        }
+
         if (nbytes < 0) {
             return SSH_ERROR;
-        }
-        if (nbytes == 0) {
-            return SSH_OK; // timeout, we're done
         }
     }
     return SSH_ERROR;


### PR DESCRIPTION
As per the docs of `ssh_channel_read_timeout`:
> The number of bytes read, 0 on end of file or SSH_ERROR
> on error. In nonblocking mode it can return 0 if no data
> is available or SSH_AGAIN.

SSH_AGAIN is -2. So it was hitting the `nbytes < 0` branch and exiting with an error. Changed it to have the same behaviour as `nbytes == 0`

Reference: https://api.libssh.org/master/group__libssh__channel.html#ga2f4e02cb3b3adbc30a534623164068fd