### PR TITLE
Fix use last @ to determine user

### DIFF
--- a/src/sshping.cxx
+++ b/src/sshping.cxx
@@ -945,7 +945,7 @@ int main(int   argc,
     user = NULL;
     addr = (char*)parse.nonOption(0);
     port = NULL;
-    char* atpos = strchr(addr, '@');
+    char* atpos = strrchr(addr, '@');
     if (atpos) {
         user = addr; *atpos = '\0';
         if (!*user) user = NULL;


### PR DESCRIPTION
A ssh user may contain `@` in it, so grabbing the first `@` instead of the last here:
https://github.com/spook/sshping/blob/b2e7c40820646561ffc03046ed85e5645a7c27eb/src/sshping.cxx#L948
Makes it so that if you use a user containing `@` the program breaks.
Such use for this, would be for example https://www.shellhub.io/.
