### PR TITLE
cmake: set cmake_minimum_required to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # See https://github.com/spook/sshping
+cmake_minimum_required(VERSION 3.10)
 project(sshping)
-cmake_minimum_required(VERSION 2.8.12)
 
 #find_package(libssh)
 


### PR DESCRIPTION
cmake-4 removes support for the minimum version being lower than 3.5, and older than 3.10 is deprecated with 3.31.

Closes: #49
Gentoo-Bug: https://bugs.gentoo.org/951814